### PR TITLE
Add Style Settings support

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,31 @@
 /* Sets all the text color to red! */
 .myalert {
-    background: red !important;
+    /* Sets the background to the colour chosen in Style Settings, using 'red' as a fallback */
+    background: var(--highlight-published-clr, red) !important;
 }
 
 .myalert-light {
-    background: rgba(255, 122, 89, .3) !important;
+    /* Uses the custom Style Settings colour with values for 'red' as a fallback */
+    --highlight-muted: rgba(var(--highlight-published-clr-rgb-r, 255), var(--highlight-published-clr-rgb-g, 122), var(--highlight-published-clr-rgb-b, 89), .3);
+    background-color: var(--highlight-muted) !important;
 }
+
+/* Setting for the Style Settings plugin */
+/* @settings
+
+name: Highlight Public Notes
+id: plugin-name
+settings:
+    - 
+        id: highlight-published-clr
+        title: Accent Color
+        description: Color used to highlight public notes.
+        type: variable-themed-color
+        format: hex
+        alt-format: 
+            -
+                id: highlight-published-clr-rgb 
+                format: rgb-split
+        default-light: '#FF0000'
+        default-dark: '#AA0000'
+*/


### PR DESCRIPTION
Hi Dennis!

Thanks for this great plugin. I use it regularly to keep track of which notes are public and which aren't.

However, I found the default 'red' too glaring and was hoping for a way to customise the highlight colour. This PR adds support for the [Style Settings Plugin](https://github.com/mgmeyers/obsidian-style-settings) to change the default colours and set different colours for dark and light mode. Fallbacks are implemented, so when Style Settings isn't installed, 'red' is set as the default.

Again, thanks for your effort in putting this plugin together. I hope Style Setting support might be a good addition to an already great plugin!